### PR TITLE
fix: quote hook paths for Windows compatibility

### DIFF
--- a/plugins/codex-peer-review/hooks/hooks.json
+++ b/plugins/codex-peer-review/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/peer-review-reminder.sh",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/peer-review-reminder.sh\"",
             "timeout": 10
           }
         ]
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/stop-peer-review-check.sh",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-peer-review-check.sh\"",
             "timeout": 5
           }
         ]
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/plan-peer-review-check.sh",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/plan-peer-review-check.sh\"",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary
- Quote the `${CLAUDE_PLUGIN_ROOT}` variable in hook commands to fix Windows path handling

## Problem
On Windows, `${CLAUDE_PLUGIN_ROOT}` expands to a path with backslashes (e.g., `C:\Users\dasbl\.claude\plugins\...`). When passed unquoted to bash, the backslashes are interpreted as escape characters and stripped, resulting in an invalid path:

```
/bin/bash: C:Usersdasbl.claudepluginscacheagent-peer-review-marketplacecodex-peer-review1.0.0/hooks/stop-peer-review-check.sh: No such file or directory
```

## Solution
Adding double quotes around the paths preserves the backslashes, allowing the hooks to work correctly on Windows systems:

```json
"command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-peer-review-check.sh\""
```

## Test plan
- [x] Verified the fix resolves the path error on Windows with Git Bash