### PR TITLE
Fix output explosion OOM: add tool-prevention, timeout, and output caps

### DIFF
--- a/plugins/codex-peer-review/commands/codex-peer-review.md
+++ b/plugins/codex-peer-review/commands/codex-peer-review.md
@@ -85,7 +85,13 @@ Validate Claude's response to this question using Codex CLI.
 
 Question: [the question from arguments]
 
-Command: codex exec "[focused prompt about the question]"
+Command: Use codex exec with output protection:
+  timeout 120 codex exec <<'EOF' 2>&1 | head -c 500000
+  [focused prompt about the question]
+
+  IMPORTANT: Do not use any tools, do not read files, do not search code.
+  Analyze ONLY the content provided in this prompt. Output text only.
+  EOF
 
 Return findings for comparison and synthesis.
 ```

--- a/plugins/codex-peer-review/hooks/hooks.json
+++ b/plugins/codex-peer-review/hooks/hooks.json
@@ -1,18 +1,6 @@
 {
-  "description": "Peer review reminder hooks - multi-point triggering for comprehensive coverage",
+  "description": "Peer review hooks - minimal set with keyword-gated detection to avoid session slowdown",
   "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/peer-review-reminder.sh",
-            "timeout": 10
-          }
-        ]
-      }
-    ],
     "UserPromptSubmit": [
       {
         "matcher": "*",
@@ -25,18 +13,6 @@
         ]
       }
     ],
-    "Stop": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/stop-peer-review-check.sh",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "ExitPlanMode",
@@ -44,26 +20,6 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/plan-peer-review-check.sh",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "Task",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/task-peer-review-check.sh",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/write-peer-review-check.sh",
             "timeout": 5
           }
         ]

--- a/plugins/codex-peer-review/hooks/task-peer-review-check.sh
+++ b/plugins/codex-peer-review/hooks/task-peer-review-check.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # PreToolUse hook for Task: Check if dispatching to a review-related agent
 
-# Read hook context from stdin (JSON)
-INPUT=$(cat)
-
-# The full JSON input contains tool parameters; check for review-related dispatch
-TOOL_INPUT="$INPUT"
+# Get tool input from environment or stdin
+TOOL_INPUT="${CLAUDE_TOOL_INPUT:-}"
+if [ -z "$TOOL_INPUT" ]; then
+  TOOL_INPUT=$(cat)
+fi
 
 # Check if this is dispatching to a code review or similar agent (but NOT our peer reviewer)
 if echo "$TOOL_INPUT" | grep -qiE "code-review|review|architect|design" && \

--- a/plugins/codex-peer-review/hooks/user-prompt-check.sh
+++ b/plugins/codex-peer-review/hooks/user-prompt-check.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 # UserPromptSubmit hook: Identify requests likely needing peer review
 
-# Read hook context from stdin (JSON)
-INPUT=$(cat)
-
-# Extract the user's prompt from JSON input
-# Try jq first, fall back to grep/cut
-if command -v jq &>/dev/null; then
-  USER_PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null)
-else
-  USER_PROMPT=$(echo "$INPUT" | grep -o '"prompt":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Get the user's prompt from environment or stdin
+USER_PROMPT="${CLAUDE_USER_PROMPT:-}"
+if [ -z "$USER_PROMPT" ]; then
+  INPUT=$(cat)
+  if command -v jq &>/dev/null; then
+    USER_PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null)
+  else
+    USER_PROMPT=$(echo "$INPUT" | grep -o '"prompt":"[^"]*"' | head -1 | cut -d'"' -f4)
+  fi
 fi
 
 # Keywords that suggest peer review would be valuable

--- a/plugins/codex-peer-review/hooks/write-peer-review-check.sh
+++ b/plugins/codex-peer-review/hooks/write-peer-review-check.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 # PreToolUse hook for Write: Check if writing significant implementation files
 
-# Read hook context from stdin (JSON)
-INPUT=$(cat)
-
-# Extract the file_path from JSON input
-# Try jq first, fall back to grep/cut
-if command -v jq &>/dev/null; then
-  FILE_PATH=$(echo "$INPUT" | jq -r '.file_path // empty' 2>/dev/null)
-else
-  FILE_PATH=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Get the file path from environment or stdin
+FILE_PATH="${CLAUDE_TOOL_INPUT:-}"
+if [ -z "$FILE_PATH" ]; then
+  INPUT=$(cat)
+  if command -v jq &>/dev/null; then
+    FILE_PATH=$(echo "$INPUT" | jq -r '.file_path // empty' 2>/dev/null)
+  else
+    FILE_PATH=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+  fi
 fi
 
 # Check if writing implementation files (not config, not docs, not tests)

--- a/plugins/codex-peer-review/skills/codex-peer-review/discussion-protocol.md
+++ b/plugins/codex-peer-review/skills/codex-peer-review/discussion-protocol.md
@@ -32,9 +32,16 @@ Every position should cite evidence from these categories **as applicable**:
 - **Capture session ID** from Round 1 using `codex exec --json` (look for `thread_id` in output)
 - **Resume session** in Round 2 using `codex exec resume [SESSION_ID]`
 - This maintains conversation context so Codex remembers Round 1 discussion
+- **Fallback:** Session resume can be unreliable — always prepare full context re-injection as backup
 - Without session continuity, Round 2 starts fresh and loses valuable context
 
-### Rule 5: Classify Disagreement Type
+### Rule 5: Output Protection (MANDATORY)
+- **Every** `codex exec` call MUST be wrapped with `timeout 120` and `| head -c 500000`
+- **Every** prompt MUST end with: "IMPORTANT: Do not use any tools, do not read files, do not search code. Analyze ONLY the content provided in this prompt. Output text only."
+- **Never** reference file paths — include all content directly in the prompt
+- Without these protections, Codex will autonomously read files and produce 10-100MB of output
+
+### Rule 6: Classify Disagreement Type
 
 | Type | Definition | Action |
 |------|------------|--------|


### PR DESCRIPTION
## Summary

Fixes two critical issues with the codex-peer-review plugin:

1. **OOM crash** — `codex exec` runs in full-auto mode and autonomously reads files, searches code, and streams JSON. For multi-file reviews, this produced 64MB+ of output that crashed the peer-reviewer agent.
2. **Hook overhead** — The current hooks.json fires on SessionStart, every UserPromptSubmit, every Stop, and three PreToolUse matchers, causing 5+ subprocess invocations per turn and measurably slowing sessions.

This PR backports defensive patterns proven in the `gemini-peer-review` fork (by stephenbrandon), adapted for Codex CLI semantics, and reduces hooks to a minimal keyword-gated set.

## Root Cause — OOM

When `codex exec` receives a prompt that references file paths, it autonomously:
1. Reads every referenced file via tool calls
2. Searches for related code across the repo
3. Streams each tool invocation as JSON (with `--json` flag)
4. The agent captures all output via `tee`

For a real-world test (8 shell scripts + a 430-line GUIDE.md), this produced a 64MB output file that OOM'd the peer-reviewer agent.

## Root Cause — Hook Overhead

Each hook spawns a bash subprocess, reads stdin/env, runs grep, and outputs text injected into context. With 6 hooks firing across SessionStart + UserPromptSubmit + Stop + 3x PreToolUse, busy sessions trigger dozens of hook invocations per conversation turn.

## Changes

### Commit 1: Output Protection

**All `codex exec` invocations:**
- **Tool-prevention suffix**: Every prompt ends with "IMPORTANT: Do not use any tools, do not read files, do not search code. Analyze ONLY the content provided in this prompt. Output text only."
- **Timeout**: All `codex exec` calls wrapped with `timeout 120` (prevents infinite tool loops)
- **Output cap**: All output piped through `head -c 500000` (caps at 500KB)

**Content Inclusion Pattern:**
- Never reference file paths — include file contents directly in prompts
- Temp file approach (`mktemp`) for large multi-file prompts
- Per-file chunking guidance for large reviews

**Agent Definition (`agents/codex-peer-reviewer.md`):**
- Removed `permissionMode: bypassPermissions` (overly permissive)
- Added new tool permissions: `mktemp`, `rm`, `timeout`, `head`, `git diff/show/log`

**Documentation:**
- New "Letting Codex Use Tools (Output Explosion)" section in `common-mistakes.md`
- New "Rule 5: Output Protection (MANDATORY)" in `discussion-protocol.md`
- New "CRITICAL: Output Protection" and "CRITICAL: Include Content in Prompts" sections in `SKILL.md`

**Hook Scripts:**
- `user-prompt-check.sh`, `task-peer-review-check.sh`, `write-peer-review-check.sh`: Try env vars first, fall back to stdin JSON parsing

### Commit 2: Hook Reduction

Reduced from 6 hooks to 2 — keeping only the ones that earn their overhead:

| Hook | Before | After | Rationale |
|------|--------|-------|-----------|
| **UserPromptSubmit** (keyword-gated) | ✅ | ✅ | Only outputs when prompt matches plan/design/review keywords. Silent otherwise. |
| **PreToolUse(ExitPlanMode)** | ✅ | ✅ | Fires only when about to present a plan. Very targeted. |
| SessionStart | ✅ | ❌ | Unconditional reminder every session — adds noise |
| Stop | ✅ | ❌ | Fires on every response completion — very noisy |
| PreToolUse(Task) | ✅ | ❌ | Fires on every subagent dispatch — too broad |
| PreToolUse(Write) | ✅ | ❌ | Fires on every file write — too broad |

## Testing

- [x] Tested `/codex-peer-review` command locally
- [x] Verified subagent dispatches correctly
- [x] Updated relevant documentation
- [x] Verified output stays under 500KB with the protections applied
- [x] Confirmed hook scripts work with both env var and stdin approaches
- [x] Verified reduced hooks don't fire on non-matching prompts

## Checklist

- [x] Prompts remain language-agnostic
- [x] No breaking changes to existing behavior (or documented if intentional)
- [x] README updated if needed (N/A — changes are internal to plugin files)