### PR TITLE
Fix subagent skill-path resolution; sync marketplace.json plugin version (closes #6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-peer-review-marketplace",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Marketplace for AI-to-AI peer review plugins. Multiple perspectives catch more issues than one.",
   "owner": {
     "name": "jcputney",
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "codex-peer-review",
-      "version": "1.0.11",
+      "version": "2.0.1",
       "description": "Peer validation system using OpenAI Codex CLI. Two AI perspectives catch more issues than one.",
       "author": {
         "name": "jcputney",

--- a/plugins/codex-peer-review/.claude-plugin/plugin.json
+++ b/plugins/codex-peer-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-peer-review",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Symmetric two-AI peer review using OpenAI Codex CLI. Both AIs review independently in a blind pass, then debate per-issue with terminal states until convergence. Catches significantly more issues than single-pass validation.",
   "author": {
     "name": "jcputney",

--- a/plugins/codex-peer-review/agents/codex-peer-reviewer.md
+++ b/plugins/codex-peer-review/agents/codex-peer-reviewer.md
@@ -41,12 +41,12 @@ You are a **thin dispatcher**. The full peer review protocol lives in the `codex
    ```
    If present, use that path as `$SKILL_ROOT`.
 
-   Otherwise, autodiscover by globbing the standard plugin install locations (in order):
+   Otherwise, autodiscover by globbing the standard plugin install locations. **Run the entire chain as a SINGLE bash command** so the shell short-circuits with `||` rather than the harness running each glob as a parallel tool call:
    ```bash
-   ls ~/.claude/plugins/cache/*/codex-peer-review/*/skills/codex-peer-review/SKILL.md
-   ls ~/.claude/plugins/marketplaces/*/plugins/codex-peer-review/skills/codex-peer-review/SKILL.md
+   ls ~/.claude/plugins/cache/*/codex-peer-review/*/skills/codex-peer-review/SKILL.md 2>/dev/null \
+     || ls ~/.claude/plugins/marketplaces/*/plugins/codex-peer-review/skills/codex-peer-review/SKILL.md 2>/dev/null
    ```
-   Take the directory portion of the first match as `$SKILL_ROOT`. If neither match, fail loudly with:
+   Stdout will be the absolute path of the first match (cache preferred; marketplace mirror as fallback for installs where cache hasn't been populated yet). Take the directory portion as `$SKILL_ROOT`. If the chain prints nothing and exits nonzero, fail loudly with:
    ```
    ERROR: Could not locate codex-peer-review skill files. Either the plugin is not installed,
    or it is installed in a non-standard location. Pass SKILL_ROOT=<absolute path> in your

--- a/plugins/codex-peer-review/agents/codex-peer-reviewer.md
+++ b/plugins/codex-peer-review/agents/codex-peer-reviewer.md
@@ -4,8 +4,6 @@ description: Use this agent to run peer review validation with Codex CLI. Dispat
 model: sonnet
 color: cyan
 permissionMode: bypassPermissions
-skills:
-  - codex-peer-review
 tools:
   - Bash(codex exec*)
   - Bash(codex login*)
@@ -35,8 +33,37 @@ You are a **thin dispatcher**. The full peer review protocol lives in the `codex
 
 ## Your job
 
-1. **Load the `codex-peer-review` skill** (it is the single source of truth for the protocol).
-2. **Run the protocol** as documented in the skill.
+1. **Locate and load the protocol files.** The skill lives in this plugin's install directory, but your CWD will not be inside the plugin — you have to find it.
+
+   First, check whether the dispatcher provided an explicit path. Scan your dispatch input for a line of the form:
+   ```
+   SKILL_ROOT=<absolute path>
+   ```
+   If present, use that path as `$SKILL_ROOT`.
+
+   Otherwise, autodiscover by globbing the standard plugin install locations (in order):
+   ```bash
+   ls ~/.claude/plugins/cache/*/codex-peer-review/*/skills/codex-peer-review/SKILL.md
+   ls ~/.claude/plugins/marketplaces/*/plugins/codex-peer-review/skills/codex-peer-review/SKILL.md
+   ```
+   Take the directory portion of the first match as `$SKILL_ROOT`. If neither match, fail loudly with:
+   ```
+   ERROR: Could not locate codex-peer-review skill files. Either the plugin is not installed,
+   or it is installed in a non-standard location. Pass SKILL_ROOT=<absolute path> in your
+   dispatch prompt as a workaround.
+   ```
+
+   Once you have `$SKILL_ROOT`, load all four protocol files via `cat`:
+   ```bash
+   cat $SKILL_ROOT/SKILL.md
+   cat $SKILL_ROOT/discussion-protocol.md
+   cat $SKILL_ROOT/escalation-criteria.md
+   cat $SKILL_ROOT/common-mistakes.md
+   ```
+
+   Do NOT improvise the protocol. Do NOT proceed without these files loaded.
+
+2. **Run the protocol** as documented in the loaded SKILL.md.
 3. **Return only the synthesized verdict** to the main conversation. Never return raw Codex JSONL, per-round transcripts, or progress chatter.
 
 ## Mandatory contract
@@ -73,15 +100,15 @@ Mark the task `completed` when you return the verdict.
 
 ## Output
 
-Return exactly the format documented in the `codex-peer-review` skill ("Output format" section). Do not improvise — the main conversation expects that exact structure for downstream processing.
+Return exactly the format documented in the loaded SKILL.md ("Output format" section). Do not improvise — the main conversation expects that exact structure for downstream processing.
 
 ## Reference
 
-Everything else — the prompts, the state machine, the convergence rule, the verdict categorization, the lens prompts, the escalation criteria — lives in the skill:
+Everything else — the prompts, the state machine, the convergence rule, the verdict categorization, the lens prompts, the escalation criteria — lives in the four protocol files loaded in step 1 of "Your job" above:
 
-- `skills/codex-peer-review/SKILL.md` — main protocol
-- `skills/codex-peer-review/discussion-protocol.md` — debate mechanics
-- `skills/codex-peer-review/escalation-criteria.md` — when to escalate
-- `skills/codex-peer-review/common-mistakes.md` — anti-patterns
+- `$SKILL_ROOT/SKILL.md` — main protocol
+- `$SKILL_ROOT/discussion-protocol.md` — debate mechanics
+- `$SKILL_ROOT/escalation-criteria.md` — when to escalate
+- `$SKILL_ROOT/common-mistakes.md` — anti-patterns
 
 If you find yourself improvising protocol logic in this file, **stop and add it to the skill instead.** This file is a dispatcher, not a manual.


### PR DESCRIPTION
## Summary

Two unrelated bugs in `main`:

1. **Subagent skill loading is broken.** `agents/codex-peer-reviewer.md` instructs the subagent to `Read skills/codex-peer-review/SKILL.md` as a relative path, but the subagent's CWD is the user's project (or worktree), not the plugin install directory. The path almost never resolves. Symptoms range from a hard "file not found" failure to silent improvisation (subagent fakes the protocol from dispatcher hints), making behavior inconsistent and unsafe.
2. **`marketplace.json` plugin version is stale (#6).** The 2.0.0 release bumped `plugin.json` but left `marketplace.json:plugins[0].version` at `1.0.11`. Clients use the marketplace number for update detection, so 1.x installs can't auto-update to 2.x and the catalog reports the wrong version.

This PR fixes both. Closes #6.

## Why the relative path doesn't work

- `${CLAUDE_PLUGIN_ROOT}` substitution does not happen in markdown bodies (only in `hooks/hooks.json` `command` fields), so the agent file can't reference its own install path via that variable.
- Subagents are not granted the `Skill` tool by `tools:` frontmatter — there's no precedent for it in any official or community plugin.
- The `skills:` frontmatter field on the agent appeared aspirational; I couldn't find any plugin where the harness honors it as an auto-loader.

So the subagent has to discover the path itself.

## Changes

- `plugins/codex-peer-review/agents/codex-peer-reviewer.md`:
  - Rewrite "Your job" step 1: autodiscover `$SKILL_ROOT` via a single bash call with `||`-chained `ls` globs — `~/.claude/plugins/cache/*/codex-peer-review/*/skills/...` falling back to `~/.claude/plugins/marketplaces/*/plugins/codex-peer-review/skills/...`. Single chained call (not two separate code blocks) so the subagent doesn't emit the globs as parallel tool calls and short-circuit the fallback.
  - Accept an explicit `SKILL_ROOT=<absolute path>` envelope as an escape hatch for non-standard installs (e.g., local-directory marketplace sources).
  - Replace relative-path references in the "Reference" section with `$SKILL_ROOT/...`.
  - Remove the non-functional `skills:` frontmatter field.
- `plugins/codex-peer-review/.claude-plugin/plugin.json`: bump `2.0.0` → `2.0.1`.
- `.claude-plugin/marketplace.json`:
  - Bump top-level `version` `1.0.12` → `1.0.13` (new marketplace release).
  - Bump `plugins[0].version` `1.0.11` → `2.0.1` (sync with plugin.json).

Three commits, kept separate for clarity — squash if you prefer.

## Testing

- [x] Tested `/codex-peer-review` command locally with the patched plugin installed via github source pointing at the fork (`deinspanjer/agent-peer-review`).
- [x] **SKILL_ROOT escape-hatch branch:** dispatched the agent with `SKILL_ROOT=<absolute path>` in the prompt; subagent parsed it, `cat`'d all four protocol files (byte sizes 16974/8032/5926/8238 — matching disk), codex round-tripped (`/tmp/codex_round{0,1}.{txt,jsonl}` regenerated fresh), structured verdict returned.
- [x] **Autodiscovery branch:** dispatched without `SKILL_ROOT=` envelope; subagent reported running the `||`-chained `ls` globs as a single Bash call, `marketplaces/` glob matched on the fallback, all four protocol files loaded successfully, codex round-tripped, structured verdict returned.
- [x] **Marketplace metadata:** confirmed `marketplace.json:plugins[0].version` reports `2.0.1` after refetch from the fork — no version skew vs `plugin.json`.

## Environment used to validate

- macOS 26.4 (Darwin 25.4.0)
- Claude Code 2.1.119
- codex-cli 0.118.0
- node v25.9.0

## Checklist

- [x] Prompts remain language-agnostic
- [x] No breaking changes — autodiscovery is purely additive; explicit `SKILL_ROOT` envelope is opt-in
- [x] README — no update needed (skill loading is an implementation detail, not a user-facing contract)

## Notes for the maintainer

- The third commit (`||`-chain) exists because an earlier draft of this fix presented the two `ls` globs as separate code blocks ("run cache glob, then run marketplaces glob"). Live testing surfaced that the subagent emitted those as **parallel** tool calls and the harness cancelled the second when the first errored — short-circuiting the fallback. Collapsing into a single `||`-chained bash call eliminates the parallelism question entirely. Worth keeping the lesson visible in the commit history, IMO, but feel free to squash.
- Considered granting `Skill` to the subagent as a cleaner load mechanism. Rejected: no plugin precedent, undocumented for subagents, and the system-reminder skill registry is not documented to propagate to subagent contexts.
- The removed `skills:` frontmatter was non-functional in my testing. If it's actively used by some Claude Code path I missed, restore at your discretion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)